### PR TITLE
Add "gatekeeper mode" view

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -8,6 +8,7 @@ import ChooseWeaponPage from './ChooseWeaponPage';
 import ChooseBossPage from './ChooseBossPage';
 import FightPage from './FightPage';
 import ErrorPage from './ErrorPage';
+import GatekeeperMode from './GatekeeperMode';
 
 function App() {
   const state = useSelector((state) => state);
@@ -23,6 +24,8 @@ function App() {
       return <ChooseBossPage {...state} />;
     case 'fight':
       return <FightPage {...state} />;
+    case 'gatekeeper_mode':
+      return <GatekeeperMode {...state} />;
     default: {
       (state.stage: empty);
       return <ErrorPage />;

--- a/src/components/FightPage.js
+++ b/src/components/FightPage.js
@@ -111,7 +111,12 @@ function FighterSection({ children, imageWidth, fighter, flipped }: FighterSecti
         </div>
       </div>
       <div className={styles.fighterRow}>
-        <Image className={styles.fighterImage} src={fighter.image} glow width={imageWidth}/>
+        <Image
+          className={styles.fighterImage}
+          src={fighter.image}
+          glow
+          width={imageWidth}
+        />
         <div className={styles.fighterInfo}>
           <div className={styles.fighterName}>{fighter.name}</div>
           <div className={styles.fighterTitle}>{fighter.title}</div>

--- a/src/components/GatekeeperMode.css
+++ b/src/components/GatekeeperMode.css
@@ -1,0 +1,5 @@
+.attackText {
+    font-size: 32px;
+    text-align: center;
+    margin: 32px;
+}

--- a/src/components/GatekeeperMode.js
+++ b/src/components/GatekeeperMode.js
@@ -21,7 +21,6 @@ class GatekeeperMode extends React.Component<GatekeeperModeStage, State> {
   }
 
   syncLocalStorageToState = () => {
-    console.log('localstorage event seen');
     this.setState({ message: window.localStorage.getItem('attackText') });
   };
 

--- a/src/components/GatekeeperMode.js
+++ b/src/components/GatekeeperMode.js
@@ -1,0 +1,37 @@
+// @flow
+import type { GatekeeperModeStage } from '../types/Stage';
+import React from 'react';
+import PageContainer from './PageContainer';
+import styles from './GatekeeperMode.css';
+
+export type State = {
+  message: String,
+};
+
+class GatekeeperMode extends React.Component<GatekeeperModeStage, State> {
+  constructor(props: GatekeeperModeStage) {
+    super(props);
+    this.state = {
+      message: window.localStorage.getItem('attackText'),
+    };
+  }
+
+  componentDidMount() {
+    window.addEventListener('storage', this.syncLocalStorageToState);
+  }
+
+  syncLocalStorageToState = () => {
+    console.log('localstorage event seen');
+    this.setState({ message: window.localStorage.getItem('attackText') });
+  };
+
+  render() {
+    return (
+      <PageContainer>
+        <div className={styles.attackText}>{this.state.message}</div>
+      </PageContainer>
+    );
+  }
+}
+
+export default GatekeeperMode;

--- a/src/config/playerWeapons.js
+++ b/src/config/playerWeapons.js
@@ -11,18 +11,67 @@ export const PRIVATE_SLACK_CHANNEL: Weapon = {
   name: 'Private Slack Channel',
   image: slackImg,
   attacks: [
-    { type: 'exclusionary', name: 'Master Lock Combo' },
-    { type: 'exclusionary', name: 'Double Padlock' },
-    { type: 'exclusionary', name: 'Insult Sling' },
-    { type: 'exclusionary', name: '“Cool People”' },
-    { type: 'exclusionary', name: '“Real Artists”' },
-    { type: 'exclusionary', name: 'Talk to the Hand' },
-    { type: 'exclusionary', name: 'Stranger Danger' },
+    {
+      type: 'exclusionary',
+      name: 'Master Lock Combo',
+      description:
+        '[Name] goes at [BOSS] with their infamous attack: The Master Lock Combination Spin',
+    },
+    {
+      type: 'exclusionary',
+      name: 'Double Padlock',
+      description: '[Name] gets in a 1-2 hit with The Double Padlock',
+    },
+    {
+      type: 'exclusionary',
+      name: 'Insult Sling',
+      description:
+        '[Name] slings insults at [BOSS] in 15 separate private channels; everybody is laughing',
+    },
+    {
+      type: 'exclusionary',
+      name: '“Cool People”',
+      description:
+        '[Name] creates a Slack channel called “Cool People” and leaves [BOSS] out',
+    },
+    {
+      type: 'exclusionary',
+      name: '“Real Artists”',
+      description:
+        '[Name] creates a Slack channel called “Real Artists” and leaves [BOSS] out',
+    },
+    {
+      type: 'exclusionary',
+      name: 'Talk to the Hand',
+      description:
+        '[Name] is chatting up some friends and practically shoves [BOSS] backward with the force of their cold shoulder. Sorry, [BOSS] who?',
+    },
+    {
+      type: 'exclusionary',
+      name: 'Stranger Danger',
+      description:
+        '[BOSS] says hi to [Name], and [Name] claims to have no idea who they are, despite having met [BOSS] at least four times. ',
+    },
 
-    { type: 'inclusive', name: 'Carpool' },
-    { type: 'inclusive', name: 'Shout-out' },
-    { type: 'inclusive', name: 'Heart2Heart' },
-    { type: 'inclusive', name: 'Bring It In!' },
+    {
+      type: 'inclusive',
+      name: 'Carpool',
+      description:
+        '[Name] @s [BOSS] in a carpool thread for next week’s decompression party. [BOSS] would love to go!',
+    },
+    {
+      type: 'inclusive',
+      name: 'Shout-out',
+      description:
+        'Shout-out - [Name] calls out [BOSS] in a public channel and says: loved your Room Service project this year!',
+    },
+    {
+      type: 'inclusive',
+      name: 'Heart2Heart',
+      description:
+        'Heart2Heart - [Name] and [BOSS] have a heart-to-heart and really bond over [INTEREST]! Hug it out ya’ll!',
+    },
+    { type: 'inclusive', name: 'Bring It In!', description: 'Bring it in!! Group hug!!' },
   ],
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,19 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import App from './components/App';
 import { createStore } from './redux/store';
+import { gatekeeperMode } from './redux/actions';
 
 import './index.css';
 
 const store = createStore();
 window.store = store;
+
+// Hacky routing -- if the user loads with the "#gatekeeper" fragment,
+// then configure the store to load the gatekeeper UI
+if (window.location.hash === '#gatekeeper') {
+  store.dispatch(gatekeeperMode());
+}
+
 ReactDOM.render(
   <Provider store={store}>
     <App />

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -107,6 +107,11 @@ export function boostBossVibes(): ChangeBossVibesAction {
   return { type: 'change_boss_vibes', payload: 1 };
 }
 
+type GatekeeperModeAction = { type: 'gatekeeper_mode' };
+export function gatekeeperMode(): GatekeeperModeAction {
+  return { type: 'gatekeeper_mode' };
+}
+
 /*
   Define the final action type as the union of all actions
 */
@@ -123,7 +128,8 @@ export type ReduxAction =
   | PerformBossAttackAction
   | ClearAttackAction
   | ChangePlayerVibesAction
-  | ChangeBossVibesAction;
+  | ChangeBossVibesAction
+  | GatekeeperModeAction;
 
 /*
   Handle actions in the reducer
@@ -246,6 +252,10 @@ export function reducer(
         boss: changeVibes(state.boss, action.payload),
         attack: null,
       };
+    }
+
+    case 'gatekeeper_mode': {
+      return { stage: 'gatekeeper_mode' };
     }
 
     default:

--- a/src/redux/gatekeeperText.js
+++ b/src/redux/gatekeeperText.js
@@ -1,0 +1,38 @@
+// @flow
+import type { ReduxMiddleware } from './store';
+
+function nameTemplate(fullText, playerName, bossName) {
+  return fullText.replace(/\[Name\]/g, playerName).replace(/\[BOSS\]/g, bossName);
+}
+
+const gatekeeperTextMiddleware: ReduxMiddleware = (store) => (next) => (action) => {
+  const result = next(action);
+  const currentState = store.getState();
+
+  if (
+    currentState.stage === 'fight' &&
+    ['perform_player_attack', 'perform_boss_attack'].includes(action.type)
+  ) {
+    if (currentState.attack) {
+      const attackObj = currentState.player.weapon.attacks.filter(
+        (attack) => currentState.attack && attack.name === currentState.attack.name,
+      );
+      if (attackObj && attackObj.length > 0) {
+        const attackTemplateText = attackObj[0].description;
+        if (attackTemplateText) {
+          const textToRead = nameTemplate(
+            attackTemplateText,
+            currentState.player.name,
+            currentState.boss.name,
+          );
+          window.localStorage.setItem('attackText', textToRead);
+        }
+      }
+    }
+  }
+
+  // $FlowFixMe - hmmm
+  return result;
+};
+
+export default gatekeeperTextMiddleware;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -13,13 +13,14 @@ import logger from 'redux-logger';
 import { type ReduxAction, reducer } from './actions';
 import { type ReduxState } from './state';
 import soundsMiddleware from './sounds';
+import gatekeeperTextMiddleware from './gatekeeperText';
 
 export type ReduxDispatch = <T: ReduxAction>(T) => T;
 export type ReduxStore = StoreGeneric<ReduxState, ReduxAction, ReduxDispatch>;
 export type ReduxMiddleware = MiddlewareGeneric<ReduxState, ReduxAction, ReduxDispatch>;
 
 export function createStore(): ReduxStore {
-  const middleware = applyMiddleware(logger, soundsMiddleware);
+  const middleware = applyMiddleware(logger, soundsMiddleware, gatekeeperTextMiddleware);
   return createStoreGeneric(reducer, middleware);
 }
 

--- a/src/types/Fighter.js
+++ b/src/types/Fighter.js
@@ -32,6 +32,8 @@ export type AttackType = 'exclusionary' | 'inclusive';
 export type Attack = {
   name: string,
   type: AttackType,
+  // Won't be optional once descriptions are written for everything
+  description?: string,
 };
 
 export type Fact = {

--- a/src/types/Stage.js
+++ b/src/types/Stage.js
@@ -28,9 +28,14 @@ export type FightStage = {
   lastPlayerAttackType: AttackType,
 };
 
+export type GatekeeperModeStage = {
+  stage: 'gatekeeper_mode',
+};
+
 export type Stage =
   | InitialStage
   | ChooseNameStage
   | ChooseWeaponStage
   | ChooseBossStage
-  | FightStage;
+  | FightStage
+  | GatekeeperModeStage;


### PR DESCRIPTION
Add a way to have a gatekeeper-only view that prompts with text to read aloud. With this change, you can load "http://localhost:8080/#gatekeeper" and see a view that will just have text for the gatekeeper to read. When the gatekeeper triggers an attack, a new piece of Redux middleware computes the text (using templating for the player's name and the boss's name) and stores it in HTML5 Local Storage. The Gatekeeper screen then listens to `storage` events and will update its view when this occurs. This allows easy IPC without any servers or sockets or similar -- the gatekeeper screen and the game screen just need to be on the same origin.

Demo:
![screencast 2019-11-18 22-26-34](https://user-images.githubusercontent.com/1550614/69122443-aa109c00-0a53-11ea-8cf5-e83ba9e42c13.gif)

For the moment, I've only added text for the "Private Slack Channel" weapon, as I wanted to validate this approach with you before doing the drudgery of importing all of the rest of the text. If this looks like a good direction to you, then I'll add the rest.

@peterkhayes 